### PR TITLE
use Lchown instead of Chown so that symbolic links are not followed

### DIFF
--- a/fixuid.go
+++ b/fixuid.go
@@ -227,7 +227,7 @@ func main() {
 			// only chown if file is containerUID:containerGID
 			if sys.Uid == containerUIDUint32 && sys.Gid == containerGIDUint32 {
 				logInfo("chown " + filePath)
-				err := syscall.Chown(filePath, runtimeUIDInt, runtimeGIDInt)
+				err := syscall.Lchown(filePath, runtimeUIDInt, runtimeGIDInt)
 				if err != nil {
 					logInfo("error changing owner of " + filePath)
 					logInfo(err)


### PR DESCRIPTION
Thank you for this very helpful tool--it solves exactly the problem I was having.

However, I noticed that symbolic links within the paths I configured were not being touched up.  This is because while `filepath.Walk` does not follow links, `syscall.Chown` does.  This is especially a problem if I have symlinks within my user path to files outside the user path that I might not want changed.  Using `Lchown` ensures that symlinks are handled the same as normal files.