### PR TITLE
call syscall.Setgroups on groups from /etc/passwd and /etc/group

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,10 +7,10 @@ jobs:
     steps:
       
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
 
     - name: Print Go Version
       run: go version

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /fixuid
 /fixuid-*.tar.gz
+
+/.idea

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ paths:
 
 ## Run in Startup Script instead of Entrypoint
 
-You can run `fixuid` as part of your container's startup script.  `fixuid` will `export HOME=/path/to/home` if $HOME is the default value of `/`, so be sure to evaluate the output of `fixuid` when running as a script.
+You can run `fixuid` as part of your container's startup script.  `fixuid` will `export HOME=/path/to/home` if $HOME is the default value of `/`, so be sure to evaluate the output of `fixuid` when running as a script.  Supplementary group membership changes on first-run will not work in this mode.
 
 ```
 #!/bin/sh

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ paths:
 
 ## Run in Startup Script instead of Entrypoint
 
-You can run `fixuid` as part of your container's startup script.  `fixuid` will `export HOME=/path/to/home` if $HOME is the default value of `/`, so be sure to evaluate the output of `fixuid` when running as a script.  Supplementary group membership changes on first-run will not work in this mode.
+You can run `fixuid` as part of your container's startup script.  `fixuid` will `export HOME=/path/to/home` if $HOME is the default value of `/`, so be sure to evaluate the output of `fixuid` when running as a script.  Supplementary groups will not be set in this mode.
 
 ```
 #!/bin/sh

--- a/docker/fs-stage/usr/local/bin/fixuid-test.sh
+++ b/docker/fs-stage/usr/local/bin/fixuid-test.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
-expected_user=$1
-expected_group=$2
+expected_user="$1"
+expected_group="$2"
+expected_groups="$3"
+if [ -z "$expected_groups" ]; then
+  expected_groups="$expected_group"
+fi
 
 if [ ! -f /var/run/fixuid.ran ]
 then
@@ -24,6 +28,13 @@ group=$(id -g -n)
 if [ "$group" != "$expected_group" ]
 then
     >&2 echo "expected group: $expected_group, actual group: $group"
+    rc=1
+fi
+
+groups=$(groups)
+if [ "$groups" != "$expected_groups" ]
+then
+    >&2 echo "expected groups: [$expected_groups], actual groups: [$groups]"
     rc=1
 fi
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,14 @@
 module github.com/boxboat/fixuid
 
-go 1.15
+go 1.20
 
 require (
-	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/go-ozzo/ozzo-config v0.0.0-20160627170238-0ff174cf5aa6
+	golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb
+)
+
+require (
+	github.com/BurntSushi/toml v1.3.2 // indirect
 	github.com/hnakamur/jsonpreprocess v0.0.0-20171017030034-a4e954386171 // indirect
-	gopkg.in/yaml.v2 v2.2.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,12 @@
-github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
-github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
+github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/go-ozzo/ozzo-config v0.0.0-20160627170238-0ff174cf5aa6 h1:T2JpXPk0mDD6uTT6vAwmd6pmaPqiHsBvP9Ggjr3UpE4=
 github.com/go-ozzo/ozzo-config v0.0.0-20160627170238-0ff174cf5aa6/go.mod h1:2RI3/USV7S8KzKNwmZtofbkg/BsCIAmeqJ5sJBWQ6T4=
 github.com/hnakamur/jsonpreprocess v0.0.0-20171017030034-a4e954386171 h1:G9nrYr376hLdDulCFOSmRiEa6X5vV6E/ANh+lQWmN4I=
 github.com/hnakamur/jsonpreprocess v0.0.0-20171017030034-a4e954386171/go.mod h1:ZSbf3Rg8HEW2bz6oeZBK8FbwS+g/s/KSrpZOx7CQSmw=
+golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb h1:mIKbk8weKhSeLH2GmUTrvx8CjkyJmnU1wFmg59CUjFA=
+golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
-gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/test.sh
+++ b/test.sh
@@ -23,7 +23,7 @@ docker run --rm --entrypoint fixuid fixuid-alpine fixuid-test.sh docker docker
 echo "\ncentos default user/group entrypoint"
 docker run --rm --entrypoint fixuid fixuid-centos fixuid-test.sh docker docker
 echo "\ndebian default user/group entrypoint"
-docker run --rm --entrypoint fixuid fixuid-debian fixuid-test.sh docker docker
+docker run --rm --entrypoint fixuid fixuid-debian fixuid-test.sh docker docker "docker users"
 
 echo "\nalpine 1001:1001 cmd"
 docker run --rm -u 1001:1001 fixuid-alpine fixuid-test.sh docker docker
@@ -45,11 +45,11 @@ docker run --rm -u 0:0 fixuid-centos fixuid-test.sh root root
 echo "\ndebian 0:0 cmd"
 docker run --rm -u 0:0 fixuid-debian fixuid-test.sh root root
 echo "\nalpine 0:0 entrypoint"
-docker run --rm -u 0:0 --entrypoint fixuid fixuid-alpine fixuid-test.sh root root
+docker run --rm -u 0:0 --entrypoint fixuid fixuid-alpine fixuid-test.sh root root "root docker"
 echo "\ncentos 0:0 entrypoint"
-docker run --rm -u 0:0 --entrypoint fixuid fixuid-centos fixuid-test.sh root root
+docker run --rm -u 0:0 --entrypoint fixuid fixuid-centos fixuid-test.sh root root "root docker"
 echo "\ndebian 0:0 entrypoint"
-docker run --rm -u 0:0 --entrypoint fixuid fixuid-debian fixuid-test.sh root root
+docker run --rm -u 0:0 --entrypoint fixuid fixuid-debian fixuid-test.sh root root "root users docker"
 
 echo "\nalpine 0:1001 cmd"
 docker run --rm -u 0:1001 fixuid-alpine fixuid-test.sh root docker
@@ -82,13 +82,13 @@ docker run --rm fixuid-alpine sh -c "fixuid-test.sh docker docker && fixuid fixu
 echo "\ncentos run twice cmd"
 docker run --rm fixuid-centos sh -c "fixuid-test.sh docker docker && fixuid fixuid-test.sh docker docker"
 echo "\ndebian run twice cmd"
-docker run --rm fixuid-debian sh -c "fixuid-test.sh docker docker && fixuid fixuid-test.sh docker docker"
+docker run --rm fixuid-debian sh -c "fixuid-test.sh docker docker && fixuid fixuid-test.sh docker docker 'docker users'"
 echo "\nalpine run twice entrypoint"
 docker run --rm --entrypoint fixuid fixuid-alpine sh -c "fixuid-test.sh docker docker && fixuid fixuid-test.sh docker docker"
 echo "\ncentos run twice entrypoint"
 docker run --rm --entrypoint fixuid fixuid-centos sh -c "fixuid-test.sh docker docker && fixuid fixuid-test.sh docker docker"
 echo "\ndebian run twice entrypoint"
-docker run --rm --entrypoint fixuid fixuid-debian sh -c "fixuid-test.sh docker docker && fixuid fixuid-test.sh docker docker"
+docker run --rm --entrypoint fixuid fixuid-debian sh -c "fixuid-test.sh docker docker 'docker users' && fixuid fixuid-test.sh docker docker 'docker users'"
 
 echo "\nalpine should not chown mount"
 docker run --rm -v $(pwd)/docker/fs-stage/tmp:/home/docker/mnt-dir -v $(pwd)/docker/fs-stage/tmp/test-file:/home/docker/mnt-file -u 1234:1234 fixuid-alpine sh -c "fixuid-test.sh docker docker && fixuid-mount-test.sh $(id -u) $(id -g)"
@@ -108,7 +108,7 @@ docker run --rm --entrypoint fixuid fixuid-alpine -q fixuid-test.sh docker docke
 echo "\ncentos quiet entrypoint"
 docker run --rm --entrypoint fixuid fixuid-centos -q fixuid-test.sh docker docker
 echo "\ndebian quiet entrypoint"
-docker run --rm --entrypoint fixuid fixuid-debian -q fixuid-test.sh docker docker
+docker run --rm --entrypoint fixuid fixuid-debian -q fixuid-test.sh docker docker 'docker users'
 
 printf "\npaths:\n  - /\n  - /home/docker\n  - /tmp/space dir\n  - /does/not/exist" >> docker/alpine/stage/etc/fixuid/config.yml
 printf "\npaths:\n  - /\n  - /home/docker\n  - /tmp/space dir\n  - /does/not/exist" >> docker/centos/stage/etc/fixuid/config.yml

--- a/test.sh
+++ b/test.sh
@@ -45,11 +45,11 @@ docker run --rm -u 0:0 fixuid-centos fixuid-test.sh root root
 echo "\ndebian 0:0 cmd"
 docker run --rm -u 0:0 fixuid-debian fixuid-test.sh root root
 echo "\nalpine 0:0 entrypoint"
-docker run --rm -u 0:0 --entrypoint fixuid fixuid-alpine fixuid-test.sh root root "root docker"
+docker run --rm -u 0:0 --entrypoint fixuid fixuid-alpine fixuid-test.sh root root "root bin daemon sys adm disk wheel floppy dialout tape video"
 echo "\ncentos 0:0 entrypoint"
-docker run --rm -u 0:0 --entrypoint fixuid fixuid-centos fixuid-test.sh root root "root docker"
+docker run --rm -u 0:0 --entrypoint fixuid fixuid-centos fixuid-test.sh root root
 echo "\ndebian 0:0 entrypoint"
-docker run --rm -u 0:0 --entrypoint fixuid fixuid-debian fixuid-test.sh root root "root users docker"
+docker run --rm -u 0:0 --entrypoint fixuid fixuid-debian fixuid-test.sh root root
 
 echo "\nalpine 0:1001 cmd"
 docker run --rm -u 0:1001 fixuid-alpine fixuid-test.sh root docker
@@ -58,11 +58,11 @@ docker run --rm -u 0:1001 fixuid-centos fixuid-test.sh root docker
 echo "\ndebian 0:1001 cmd"
 docker run --rm -u 0:1001 fixuid-debian fixuid-test.sh root docker
 echo "\nalpine 0:1001 entrypoint"
-docker run --rm -u 0:1001 --entrypoint fixuid fixuid-alpine fixuid-test.sh root docker
+docker run --rm -u 0:1001 --entrypoint fixuid fixuid-alpine fixuid-test.sh root docker "docker root bin daemon sys adm disk wheel floppy dialout tape video"
 echo "\ncentos 0:1001 entrypoint"
-docker run --rm -u 0:1001 --entrypoint fixuid fixuid-centos fixuid-test.sh root docker
+docker run --rm -u 0:1001 --entrypoint fixuid fixuid-centos fixuid-test.sh root docker "docker root"
 echo "\ndebian 0:1001 entrypoint"
-docker run --rm -u 0:1001 --entrypoint fixuid fixuid-debian fixuid-test.sh root docker "docker users"
+docker run --rm -u 0:1001 --entrypoint fixuid fixuid-debian fixuid-test.sh root docker "docker root"
 
 echo "\nalpine 1001:0 cmd"
 docker run --rm -u 1001:0 fixuid-alpine fixuid-test.sh docker root

--- a/test.sh
+++ b/test.sh
@@ -10,7 +10,7 @@ rm -rf docker/centos/stage
 cp -r docker/fs-stage docker/centos/stage
 rm -rf docker/debian/stage
 cp -r docker/fs-stage docker/debian/stage
-docker-compose build
+docker compose build
 
 echo "\nalpine default user/group cmd"
 docker run --rm fixuid-alpine fixuid-test.sh docker docker
@@ -36,7 +36,7 @@ docker run --rm -u 1001:1001 --entrypoint fixuid fixuid-alpine fixuid-test.sh do
 echo "\ncentos 1001:1001 entrypoint"
 docker run --rm -u 1001:1001 --entrypoint fixuid fixuid-centos fixuid-test.sh docker docker
 echo "\ndebian 1001:1001 entrypoint"
-docker run --rm -u 1001:1001 --entrypoint fixuid fixuid-debian fixuid-test.sh docker docker
+docker run --rm -u 1001:1001 --entrypoint fixuid fixuid-debian fixuid-test.sh docker docker "docker users"
 
 echo "\nalpine 0:0 cmd"
 docker run --rm -u 0:0 fixuid-alpine fixuid-test.sh root root
@@ -62,7 +62,7 @@ docker run --rm -u 0:1001 --entrypoint fixuid fixuid-alpine fixuid-test.sh root 
 echo "\ncentos 0:1001 entrypoint"
 docker run --rm -u 0:1001 --entrypoint fixuid fixuid-centos fixuid-test.sh root docker
 echo "\ndebian 0:1001 entrypoint"
-docker run --rm -u 0:1001 --entrypoint fixuid fixuid-debian fixuid-test.sh root docker
+docker run --rm -u 0:1001 --entrypoint fixuid fixuid-debian fixuid-test.sh root docker "docker users"
 
 echo "\nalpine 1001:0 cmd"
 docker run --rm -u 1001:0 fixuid-alpine fixuid-test.sh docker root
@@ -71,11 +71,11 @@ docker run --rm -u 1001:0 fixuid-centos fixuid-test.sh docker root
 echo "\ndebian 1001:0 cmd"
 docker run --rm -u 1001:0 fixuid-debian fixuid-test.sh docker root
 echo "\nalpine 1001:0 entrypoint"
-docker run --rm -u 1001:0 --entrypoint fixuid fixuid-alpine fixuid-test.sh docker root
+docker run --rm -u 1001:0 --entrypoint fixuid fixuid-alpine fixuid-test.sh docker root "root docker"
 echo "\ncentos 1001:0 entrypoint"
-docker run --rm -u 1001:0 --entrypoint fixuid fixuid-centos fixuid-test.sh docker root
+docker run --rm -u 1001:0 --entrypoint fixuid fixuid-centos fixuid-test.sh docker root "root docker"
 echo "\ndebian 1001:0 entrypoint"
-docker run --rm -u 1001:0 --entrypoint fixuid fixuid-debian fixuid-test.sh docker root
+docker run --rm -u 1001:0 --entrypoint fixuid fixuid-debian fixuid-test.sh docker root "root users docker"
 
 echo "\nalpine run twice cmd"
 docker run --rm fixuid-alpine sh -c "fixuid-test.sh docker docker && fixuid fixuid-test.sh docker docker"
@@ -113,7 +113,7 @@ docker run --rm --entrypoint fixuid fixuid-debian -q fixuid-test.sh docker docke
 printf "\npaths:\n  - /\n  - /home/docker\n  - /tmp/space dir\n  - /does/not/exist" >> docker/alpine/stage/etc/fixuid/config.yml
 printf "\npaths:\n  - /\n  - /home/docker\n  - /tmp/space dir\n  - /does/not/exist" >> docker/centos/stage/etc/fixuid/config.yml
 printf "\npaths:\n  - /\n  - /home/docker\n  - /tmp/space dir\n  - /does/not/exist" >> docker/debian/stage/etc/fixuid/config.yml
-docker-compose build
+docker compose build
 
 echo "\nalpine 1001:1001 cmd"
 docker run --rm -u 1001:1001 -v /home/docker -v "/tmp/space dir" fixuid-alpine fixuid-test.sh docker docker
@@ -126,4 +126,4 @@ docker run --rm -u 1001:1001 -v /home/docker -v "/tmp/space dir" --entrypoint fi
 echo "\ncentos 1001:1001 entrypoint"
 docker run --rm -u 1001:1001 -v /home/docker -v "/tmp/space dir" --entrypoint fixuid fixuid-centos fixuid-test.sh docker docker
 echo "\ndebian 1001:1001 entrypoint"
-docker run --rm -u 1001:1001 -v /home/docker -v "/tmp/space dir" --entrypoint fixuid fixuid-debian fixuid-test.sh docker docker
+docker run --rm -u 1001:1001 -v /home/docker -v "/tmp/space dir" --entrypoint fixuid fixuid-debian fixuid-test.sh docker docker "docker users"


### PR DESCRIPTION
Fixes #30 

After UID/GID changes have been made, group membership that didn't match on container launch in `/etc/passwd` and `/etc/groups` may now match

This can be changed with `syscall.Setgroups` but will only remain effective if the next program is called via `exec`.  In "command" mode the child process calling `syscall.Setgroups` won't affect the parent.

It also shouldn't need to be run on subsequent starts, because the container start process should resolve the proper groups from `/etc/passwd` and `/etc/group` after these files have already been changed