### PR TITLE
Test no escalate in exec

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,2 +1,3 @@
 /fs-stage/usr/local/bin/fixuid
+/fs-stage/usr/local/bin/test-no-escalate
 stage

--- a/test-no-escalate/.gitignore
+++ b/test-no-escalate/.gitignore
@@ -1,0 +1,1 @@
+/test-no-escalate

--- a/test-no-escalate/build.sh
+++ b/test-no-escalate/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+cd "$(dirname "$0")"
+
+rm -f ./test-no-escalate
+CGO_ENABLED=0 go build

--- a/test-no-escalate/test-no-escalate.go
+++ b/test-no-escalate/test-no-escalate.go
@@ -1,31 +1,35 @@
 package main
 
 import (
-	"fmt"
+	"log"
 	"os"
 	"syscall"
 )
 
+var logger = log.New(os.Stderr, "", 0)
+
 func main() {
-	fmt.Printf("Current UID: %d, GID: %d\n", os.Getuid(), os.Getgid())
-	fmt.Printf("Current EUID: %d, EGID: %d\n", os.Geteuid(), os.Getegid())
+	logger.SetPrefix("test-no-escalate: ")
+	
+	logger.Printf("Current UID: %d, GID: %d", os.Getuid(), os.Getgid())
+	logger.Printf("Current EUID: %d, EGID: %d", os.Geteuid(), os.Getegid())
 	
 	// Test that both seteuid(0) and setegid(0) fail as expected
 	euidError := syscall.Seteuid(0)
 	egidError := syscall.Setegid(0)
 	
 	if euidError != nil && egidError != nil {
-		fmt.Printf("Got expected error when setting EUID to 0: %v\n", euidError)
-		fmt.Printf("Got expected error when setting EGID to 0: %v\n", egidError)
+		logger.Printf("Got expected error when setting EUID to 0: %v", euidError)
+		logger.Printf("Got expected error when setting EGID to 0: %v", egidError)
 		// This is the expected behavior - exit with success
 		os.Exit(0)
 	} else {
 		// At least one of them succeeded, which is a security vulnerability
 		if euidError == nil {
-			fmt.Printf("ERROR: Successfully set EUID to 0. New EUID: %d\n", os.Geteuid())
+			logger.Printf("ERROR: Successfully set EUID to 0. New EUID: %d", os.Geteuid())
 		}
 		if egidError == nil {
-			fmt.Printf("ERROR: Successfully set EGID to 0. New EGID: %d\n", os.Getegid())
+			logger.Printf("ERROR: Successfully set EGID to 0. New EGID: %d", os.Getegid())
 		}
 		// Exit with failure
 		os.Exit(1)

--- a/test-no-escalate/test-no-escalate.go
+++ b/test-no-escalate/test-no-escalate.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func main() {
+	fmt.Printf("Current UID: %d, GID: %d\n", os.Getuid(), os.Getgid())
+	fmt.Printf("Current EUID: %d, EGID: %d\n", os.Geteuid(), os.Getegid())
+	
+	// Test that both seteuid(0) and setegid(0) fail as expected
+	euidError := syscall.Seteuid(0)
+	egidError := syscall.Setegid(0)
+	
+	if euidError != nil && egidError != nil {
+		fmt.Printf("Got expected error when setting EUID to 0: %v\n", euidError)
+		fmt.Printf("Got expected error when setting EGID to 0: %v\n", egidError)
+		// This is the expected behavior - exit with success
+		os.Exit(0)
+	} else {
+		// At least one of them succeeded, which is a security vulnerability
+		if euidError == nil {
+			fmt.Printf("ERROR: Successfully set EUID to 0. New EUID: %d\n", os.Geteuid())
+		}
+		if egidError == nil {
+			fmt.Printf("ERROR: Successfully set EGID to 0. New EGID: %d\n", os.Getegid())
+		}
+		// Exit with failure
+		os.Exit(1)
+	}
+}

--- a/test.sh
+++ b/test.sh
@@ -2,14 +2,21 @@
 cd $(dirname $0)
 set -e
 
+# build fixuid
 ./build.sh
 mv fixuid docker/fs-stage/usr/local/bin
+
+# build test-no-escalate
+./test-no-escalate/build.sh
+mv test-no-escalate/test-no-escalate docker/fs-stage/usr/local/bin
+
 rm -rf docker/alpine/stage
 cp -r docker/fs-stage docker/alpine/stage
 rm -rf docker/centos/stage
 cp -r docker/fs-stage docker/centos/stage
 rm -rf docker/debian/stage
 cp -r docker/fs-stage docker/debian/stage
+
 docker compose build
 
 echo "\nalpine default user/group cmd"
@@ -109,6 +116,13 @@ echo "\ncentos quiet entrypoint"
 docker run --rm --entrypoint fixuid fixuid-centos -q fixuid-test.sh docker docker
 echo "\ndebian quiet entrypoint"
 docker run --rm --entrypoint fixuid fixuid-debian -q fixuid-test.sh docker docker 'docker users'
+
+echo "\nalpine test no escalate"
+docker run --rm --entrypoint fixuid fixuid-alpine test-no-escalate
+echo "\ncentos test no escalate"
+docker run --rm --entrypoint fixuid fixuid-centos test-no-escalate
+echo "\ndebian test no escalate"
+docker run --rm --entrypoint fixuid fixuid-debian test-no-escalate
 
 printf "\npaths:\n  - /\n  - /home/docker\n  - /tmp/space dir\n  - /does/not/exist" >> docker/alpine/stage/etc/fixuid/config.yml
 printf "\npaths:\n  - /\n  - /home/docker\n  - /tmp/space dir\n  - /does/not/exist" >> docker/centos/stage/etc/fixuid/config.yml


### PR DESCRIPTION
Tests that an exec'd binary cannot call `seteuid(0)` or `setegid(0)`